### PR TITLE
Set correct Accept: header when downloading cards

### DIFF
--- a/chrome/content/inverse-library/sogoWebDAV.js
+++ b/chrome/content/inverse-library/sogoWebDAV.js
@@ -175,7 +175,13 @@ sogoWebDAV.prototype = {
         let httpChannel = channel.QueryInterface(Components.interfaces.nsIHttpChannel);
         httpChannel.loadFlags |= Components.interfaces.nsIRequest.LOAD_BYPASS_CACHE;
         httpChannel.notificationCallbacks = this;
-        httpChannel.setRequestHeader("accept", "text/xml", false);
+        if (headers && headers.accept) {
+            httpChannel.setRequestHeader("accept", headers.accept, false);
+            delete headers.accept;
+        }
+        else {
+            httpChannel.setRequestHeader("accept", "text/xml", false);
+        }
         httpChannel.setRequestHeader("accept-charset", "utf-8,*;q=0.1", false);
         if (headers) {
             for (let header in headers) {
@@ -308,7 +314,11 @@ sogoWebDAV.prototype = {
 
     load: function(operation, parameters) {
         if (operation == "GET") {
-            this._sendHTTPRequest(operation);
+	    var headers = {};
+	    if (parameters.accept !== null) {
+		headers.accept = parameters.accept;
+	    }
+            this._sendHTTPRequest(operation, null, headers);
         }
         else if (operation == "PUT" || operation == "POST") {
 	    if(parameters.contentType.indexOf("text/vcard") == 0) {
@@ -373,8 +383,8 @@ sogoWebDAV.prototype = {
         else
             throw ("operation '" + operation + "' is not currently supported");
     },
-    get: function() {
-        this.load("GET");
+    get: function(accept) {
+        this.load("GET", {accept: accept});
     },
     put: function(data, contentType) {
         this.load("PUT", {data: data, contentType: contentType});

--- a/chrome/content/sogo-connector/general/sync.addressbook.groupdav.js
+++ b/chrome/content/sogo-connector/general/sync.addressbook.groupdav.js
@@ -335,7 +335,7 @@ GroupDavSynchronizer.prototype = {
                 let data = {query: "vcard-download", data: key};
                 this.remainingDownloads++;
                 let request = new sogoWebDAV(fileUrl, this, data);
-                request.get();
+                request.get("text/vcard");
             }
         }
 
@@ -360,7 +360,7 @@ GroupDavSynchronizer.prototype = {
                 let data = {query: "list-download", data: key};
                 this.remainingDownloads++;
                 let request = new sogoWebDAV(fileUrl, this, data);
-                request.get();
+                request.get("text/vcard");
             }
         }
 


### PR DESCRIPTION
Fixes [#3042](http://www.sogo.nu/bugs/view.php?id=3042).

When doing a GET for a specific card, Connector uses the default `Accept: text/xml` header. Servers that care about this header to do content type conversion (eg Cyrus) have no valid conversion for this, and reject the request with a 406 error.

This allows the library `get()` to explicitly set the accept header, and then sets it to `text/vcard` where cards are requested.

Its a bit of a brute-force fix but it works. If you want to solve it in a more generic way, go for it. I'd really like something done soon though as many of my customers (FastMail) want to use Connector for our new CardDAV service.
