### PR TITLE
Strip off header lines downloading cards or lists

### DIFF
--- a/chrome/content/sogo-connector/general/sync.addressbook.groupdav.js
+++ b/chrome/content/sogo-connector/general/sync.addressbook.groupdav.js
@@ -411,10 +411,11 @@ GroupDavSynchronizer.prototype = {
     onCardDownloadComplete: function(status, data, key) {
         this.remainingDownloads--;
         this.progressMgr.updateAddressBook(this.gURL);
+        let pos;
         if (Components.isSuccessCode(status)
             && data
-            && (data.toLowerCase().indexOf("begin:vcard") == 0))
-            this.importCard(key, data);
+            && ((pos = data.toLowerCase().indexOf("begin:vcard")) >= 0))
+            this.importCard(key, data.substr(pos));
         else
             this.appendFailure(status, key);
 
@@ -427,10 +428,11 @@ GroupDavSynchronizer.prototype = {
     onListDownloadComplete: function(status, data, key) {
         this.remainingDownloads--;
         this.progressMgr.updateAddressBook(this.gURL);
+        let pos;
         if (Components.isSuccessCode(status)
             && data
-            && (data.toLowerCase().indexOf("begin:vlist") == 0))
-            this.importList(key, data);
+            && ((pos = data.toLowerCase().indexOf("begin:vlist")) >= 0))
+            this.importList(key, data.substr(pos));
         else
             this.appendFailure(status, key);
         if (this.remainingDownloads == 0) {


### PR DESCRIPTION
Some servers (namely Kerio Connect) send some header lines in response before the actual BEGIN:VCARD or BEGIN:VLIST. This change does not require those keywords to be on the first position and simply delete leading "garbage" before importing them.
This should not affect any servers that do not send anything before BEGIN.
