### PR TITLE
Set groupDavKey before uploading card

### DIFF
--- a/chrome/content/sogo-connector/general/sync.addressbook.groupdav.js
+++ b/chrome/content/sogo-connector/general/sync.addressbook.groupdav.js
@@ -251,6 +251,7 @@ GroupDavSynchronizer.prototype = {
                     // this.dumpCard(card);
                     dump("  new card '" + card.displayName + "' will be uploaded\n");
                     key = new UUID() + ".vcf";
+                    card.setProperty(kNameKey, key);
                     this.localCardUploads[key] = card;
                     uploads++;
                 }

--- a/chrome/content/sogo-connector/general/sync.addressbook.groupdav.js
+++ b/chrome/content/sogo-connector/general/sync.addressbook.groupdav.js
@@ -671,6 +671,7 @@ GroupDavSynchronizer.prototype = {
             dump("  new card\n");
             this.gAddressBook.addCard(card);
             this.localCardPointerHash[key] = card;
+            this.localCardVersionHash[key] = card.getProperty(kETagKey, "-1");
         }
     },
     importList: function(key, data) {


### PR DESCRIPTION
This avoids a warning ("sending card with empty key") and fixes a problem on Kerio Connect and maybe some other CardDAV implementations:
After creating a contact in Thunderbird, syncing it back without changes and edit this contact in Thunderbird to re-upload to server ended up in a duplicated contact on server. This is caused by the fact that the vcard (which creates UID from groupDavKey) is being called before the key is set on the card, leaving CardUID null. The server in my case creates a unique CardUID for its response, but next time it is being sent, the groupDavKey is being used, resulting in another new card instead of modifying the existing one.
