### PR TITLE
correct German locale to match original label

### DIFF
--- a/chrome/locale/de-DE/sogo-connector/addressbook/pref-directory-add.dtd
+++ b/chrome/locale/de-DE/sogo-connector/addressbook/pref-directory-add.dtd
@@ -23,8 +23,8 @@
 -->
 
 <!ENTITY newDirectoryTitle.label          "Remote-Adressbuch Einstellungen">
-<!ENTITY groupdavName.label               "Verbindungsname: ">
-<!ENTITY groupdavName.accesskey           "n">
+<!ENTITY groupdavName.label               "Adressbuch-Name: ">
+<!ENTITY groupdavName.accesskey           "A">
 <!ENTITY groupdavURL.label                "URL: ">
 <!ENTITY groupdavURL.accesskey            "l">
 <!ENTITY groupdavHostname.label           "Host: ">


### PR DESCRIPTION
The addressbook name is common and used in Thunderbird as well, there's no sense to name it "connection name". I changed it back to "addressbook name" which makes this
