### PR TITLE
Fix notification in case of server side deletes

### DIFF
--- a/chrome/content/sogo-connector/general/sync.addressbook.groupdav.js
+++ b/chrome/content/sogo-connector/general/sync.addressbook.groupdav.js
@@ -1734,9 +1734,9 @@ function GetSyncNotifyGroupdavAddressbook(uri, ab, origin) {
                 if (cbData.synchronizer.serverDownloadsCount > 1)
                     texte += cbData.synchronizer.serverDownloadsCount+cbData.notificationsStrings['notificationsDownloads'];
 
-                if (cbData.synchronizer.serverDeletes <= 1)
+                if (cbData.synchronizer.serverDeletes.length <= 1)
                     texte += cbData.synchronizer.serverDeletes.length+cbData.notificationsStrings['notificationsDelete'];
-                if (cbData.synchronizer.serverDeletes > 1)
+                if (cbData.synchronizer.serverDeletes.length > 1)
                     texte += cbData.synchronizer.serverDeletes.length+cbData.notificationsStrings['notificationsDeletes'];
                
             } else {


### PR DESCRIPTION
A non-empty array is neither less, greater or equal to 1 - I changed it to compare against the array length, as it is used in the notification text. :)
