### PR TITLE
Fix an issue when adding a new contact

### DIFF
--- a/chrome/content/inverse-library/sogoWebDAV.js
+++ b/chrome/content/inverse-library/sogoWebDAV.js
@@ -342,7 +342,8 @@ sogoWebDAV.prototype = {
                         dump("NOTICE: uploading modified vcard without etag\n");
 	                this._sendHTTPRequest(operation,
                                               parameters.data,
-                                              { "content-type": parameters.contentType });
+					      { "content-type": parameters.contentType,
+				              "If-None-Match": "*" });
                     }
                 }
 	    }


### PR DESCRIPTION
This comit fix an issue with the Zimbra CardDav backend (at least) when adding a new contact according to RFC rfc6352.

In the PUT HTTP request, the header "If-None-Match: *" was missing when adding a new contact and Zimbra was responding with HTTP CODE 409 after a DavException (item does not exists).
