### PR TITLE
fix vCard version 4 defaultCharset

### DIFF
--- a/chrome/content/sogo-connector/general/vcards.utils.js
+++ b/chrome/content/sogo-connector/general/vcards.utils.js
@@ -255,7 +255,7 @@ function CreateCardFromVCF(vcard) {
             version = vcard[i]["values"][0];
         }
     }
-    if (version[0] == "3")
+    if (version[0] >= "3")
         defaultCharset = "utf-8";
 
     for (let i = 0; i < vcard.length; i++) {


### PR DESCRIPTION
If the following vCard contains non-ascii characters, they are now correctly displayed (as of rfc6350#page-5 only utf-8 is a valid charset):

BEGIN:VCARD
VERSION:4.0
PRODID:+//IDN bitfire.at//DAVdroid/1.0.9.1 vcard4android ez-vcard/0.9.10
.....
.....
