### PR TITLE
Do not overwrite Categories property without checking content and without asking the user

### DIFF
--- a/chrome/content/sogo-connector/addressbook/common-card-overlay.js
+++ b/chrome/content/sogo-connector/addressbook/common-card-overlay.js
@@ -38,14 +38,6 @@ function SCOnCommonCardOverlayLoad() {
         SCOnCommonCardOverlayLoadPreHook();
     }
     /* categories */
-    /* migration from MoreFunctionsblabla */
-    let cardCategoriesValue = gEditCard.card.getProperty("Category", "");
-    if (cardCategoriesValue.length > 0) {
-        let migrationValue = cardCategoriesValue.split(", ").join("\u001A");
-        gEditCard.card.setProperty("Categories", migrationValue);
-        gEditCard.card.setProperty("Category", "");
-    }
-
     cardCategoriesValue = gEditCard.card.getProperty("Categories", "");
     let catsArray = multiValueToArray(cardCategoriesValue);
     gSCCardValues.categories = SCContactCategories.getCategoriesAsArray();


### PR DESCRIPTION
This "migration" is overwriting any value in the categories property, if there is something in the category property. So if the user happens to use both properties, he will lose data.

As a quick fix, I would just remove the migration. Anyhow, you should not manipulate user data without asking.