### PR TITLE
Support for "All Address Books"

### DIFF
--- a/chrome/content/sogo-connector/addressbook/common-card-overlay.js
+++ b/chrome/content/sogo-connector/addressbook/common-card-overlay.js
@@ -156,7 +156,12 @@ function SCSaveCategories() {
 function getUri() {
     let uri;
 
-    if (document.getElementById("abPopup")) {
+    if (gEditCard.abURI && gEditCard.abURI == kAllDirectoryRoot + "?") { // Find the correct address book for "All Address Books"
+        let dirId = gEditCard.card.directoryId
+                             .substring(0, gEditCard.card.directoryId.indexOf("&"));
+        uri = MailServices.ab.getDirectoryFromId(dirId).URI;
+    }
+    else if (document.getElementById("abPopup")) {
         uri = document.getElementById("abPopup").value;
     }
     else if (window.arguments[0].abURI) {


### PR DESCRIPTION
Thunderbird 38 added an "All Address Books" address book that displayed all contacts from all address books. Changes made there were never synced to the server because the correct address book name was never obtained. This has previously been reported at https://lists.inverse.ca/sogo/arc/users/2016-03/msg00076.html, but incorrectly blamed on Thunderbird. My pull request adds some special treatment for "All Address Books" so that it is resolved to the correct address book.

Furthermore, clicking on an email address in the headers of a message and selecting "Add Contact"/"Edit Contact" or clicking on the star next to such an email address also resulted in contacts never being synced to the server. Fixing this appears to not be possible via a XUL override, but instead would require overriding the `AddContact` and `EditContact` functions as this does not go through the same code path as direct address book edits. ~~Therefore, I have disabled this broken functionality.~~

Overall, I believe that my pull request should take care of all situations where contacts could be added/modified without SOGo Connector marking them as dirty and syncing them.