### PR TITLE
assume type=jpg when vCard does not provide TYPE

### DIFF
--- a/chrome/content/sogo-connector/general/vcards.utils.js
+++ b/chrome/content/sogo-connector/general/vcards.utils.js
@@ -937,7 +937,6 @@ function importPhoto(photoType, content) {
     let photoFile = null;
 
     if (content && content.length > 0) {
-        let ext = deducePhotoExtFromTypes(photoType);
         if (photoType) {
             let ext = deducePhotoExtFromTypes(photoType);
             if (ext) {

--- a/chrome/content/sogo-connector/general/vcards.utils.js
+++ b/chrome/content/sogo-connector/general/vcards.utils.js
@@ -938,12 +938,19 @@ function importPhoto(photoType, content) {
 
     if (content && content.length > 0) {
         let ext = deducePhotoExtFromTypes(photoType);
-        if (ext) {
-            photoFile = saveImportedPhoto(content, ext);
+        if (photoType) {
+            let ext = deducePhotoExtFromTypes(photoType);
+            if (ext) {
+                photoFile = saveImportedPhoto(content, ext);
+            }
+            else {
+                dump("vcards.utils: no extension returned for photo file\n");
+            }
         }
         else {
-            dump("vcards.utils: no extension returned for photo file\n");
-        }
+          dump("vcards.utils: no photo type provided, assuming jpg\n");
+          photoFile = saveImportedPhoto(content, 'jpg');
+       }
     }
     else {
         dump("vcards.utils: no content provided\n");


### PR DESCRIPTION
Latest SOGo version does not sent TYPE with vCard picture thus making SOGo Connector unable to import/display profile picture for sync-ed users.

This fix assumes photo is jpg format when no TYPE is provided. It even works for PNG pictures.
This is probably not something to import in master unless other vCard providers make the same mistake, but as I modified the code for our instance until the backend bug is fixed, I figured I'd share it.

See https://sogo.nu/bugs/view.php?id=4279 for more details.